### PR TITLE
Change what the default for the `exhaustive_counter_examples` is.

### DIFF
--- a/svcb/svcb/benchmark.py
+++ b/svcb/svcb/benchmark.py
@@ -167,6 +167,14 @@ def getBenchmarks(benchSpec, addImplicitVerificationTasks=True):
         if task not in verificationTasks:
           verificationTasks[task] = copy.deepcopy(properties)
 
+    # Add implicit `exhaustive_counter_examples` field.
+    for (task, properties) in benchSpecCopy['verification_tasks'].items():
+      if properties['correct'] is False and not 'exhaustive_counter_examples' in properties:
+        if 'counter_examples' in properties:
+          properties['exhaustive_counter_examples'] = True
+        else:
+          properties['exhaustive_counter_examples'] = False
+
     # Finally build the object
     benchmarkObjs.append(Benchmark(benchSpecCopy))
 

--- a/svcb/svcb/schema.yml
+++ b/svcb/svcb/schema.yml
@@ -54,8 +54,9 @@ definitions:
             # the particular verification task.
             type: "null"
       counter_examples:
-        # List of some possible counter examples to correctness (i.e. bugs).
-        # There is no requirement for this list to be exhaustive.
+        # Array of possible counter examples to correctness (i.e. bugs).
+        #
+        # Whether or not this list is exhaustive is dependent on `exhaustive_counter_examples`.
         type: array
         minItems: 1
         uniqueItems: true
@@ -94,10 +95,19 @@ definitions:
       description:
         type: string
       exhaustive_counter_examples:
-        # If specified and true this indicates that the listed counter examples is an exhaustive list.
-        # I.e. there should not be any other property violations other than those listed. If
-        # `exhaustive_counter_examples` is false or not specified then the list of counter examples
-        # may or may not be exhaustive.
+        # FIXME: This property's defaults are complicated we should make it required if `correct` is set to False.
+        #
+        # This property **only has meaning** if `correct` is set to false.
+        #
+        # If this property is not specified and counter examples are specified this property is implicitly assumed to be true.
+        # If this property is not specified and counter examples are **not** specified this property is implicitly assumed to be false.
+        #
+        # If this property is true then the listed counter examples are
+        # exhaustive (i.e. it should not be possible to observe a counter
+        # example for the relevant property other than those listed).
+        #
+        # If this property is false then the listed counter examples are not
+        # exhaustive (i.e. is permissible to observe any counter example to the property).
         type: boolean
     additionalProperties: false
     required:


### PR DESCRIPTION
Change what the default for the `exhaustive_counter_examples` is.

Now if `correct` is false then it is implicitly true if counter examples
are specified and is implicitly false if none are provided.

The motivation behind this change is that the default is not very
beneficial because the idea behind having counter examples is to
try to prevent a verifier from pretending it found a bug by checking
the counter example it gives. Previously the default was non exhaustive
so this information couldn't actually be used to our advantage.

Technically this is change deserves a schema version bump however
that's quite a bit of work and I don't think anyone was relying
on the behaviour of this attribute so it's probably early enough
that we can make this change without adversely effecting users.

Another change here is that the implicit behaviour is made explicit
when creating a benchmark object. The result of doing this is that
generated augmented spec files will explicitly provide this property.